### PR TITLE
meson.build: use pkg-config to find libplacebo

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,9 +4,7 @@ project('vs-placebo', ['c', 'cpp'],
     version: '1.2'
 )
 
-cc = meson.get_compiler('c')
-
-placebo = cc.find_library('placebo', required: true)
+placebo = dependency('libplacebo', required: true)
 vapoursynth_dep = dependency('vapoursynth').partial_dependency(includes: true, compile_args: true)
 
 sources = ['vs-placebo.c', 'deband.c', 'tonemap.c', 'resample.c', 'shader.c']


### PR DESCRIPTION
`cc.find_library` won't find the library if it's not installed into standard locations and it also won't add proper `CFLAGS` to access its headers.