### PR TITLE
Deband: properly advance frame PRNG

### DIFF
--- a/deband.c
+++ b/deband.c
@@ -17,6 +17,7 @@ typedef struct {
     struct pl_dither_params *ditherParams;
     struct pl_deband_params *debandParams;
     int renderer; // for debugging purposes
+    uint8_t frame_index;
     pthread_mutex_t lock;
 } MData;
 
@@ -27,6 +28,11 @@ bool do_plane(struct priv *p, void* data, int chroma)
     if (!d->renderer) {
 
         struct pl_shader *sh = pl_dispatch_begin(p->dp);
+        pl_shader_reset(sh, &(struct pl_shader_params) {
+            .gpu = p->gpu,
+            .index = d->frame_index++,
+        });
+
         int new_depth = p->tex_out[0]->params.format->component_depth[0];
         pl_shader_deband(sh, &(struct pl_sample_src) {.tex = p->tex_in[0]},
                          d->debandParams);


### PR DESCRIPTION
The current deband filter does not actually do a very good job
debanding, because it doesn't advance the internal PRNG in any way. This
is mostly my fault for not exposing `pl_dispatch_reset_frame`, which is
what e.g. pl_renderer uses internally to advance the PRNG state. On
newer libplacebo (v4.167+), that's the function we should be calling to
fix this.

As a work-around, that also works for older libplacebo, we can simply
`pl_shader_reset` the shaders we get from `pl_dispatch_begin` to include
a frame index of our choosing, without breaking anything.