### PR TITLE
Allow linking to libdovi for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,121 @@
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_dispatch:
+
+name: vs-placebo build
+
+jobs:
+  build_vs_placebo:
+    name: Building vs-placebo
+    runs-on: ubuntu-latest
+    env:
+      CURL_RETRIES: "--connect-timeout 60 --retry 999 --retry-delay 5 --retry-all-errors"
+    container:
+      image: docker://archlinux:base-devel
+
+    steps:
+
+      - name: Get current date and random hash
+        run: |
+          echo "short_date=$(date "+%Y%m%d")" >> $GITHUB_ENV
+          echo "random_hash=$(echo $RANDOM | md5sum | head -c 20)" >> $GITHUB_ENV
+
+      - name: Installing dependencies
+        run: |
+          echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm --needed jq openssh git gyp mercurial subversion ninja \
+            cmake ragel yasm nasm asciidoc enca gperf unzip p7zip gcc-multilib clang \
+            python-pip curl lib32-glib2 wget rustup cargo-c
+
+          pip3 install rst2pdf mako meson
+          git config --global user.name "github-actions"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global --add safe.directory $PWD
+
+      - uses: actions/checkout@v3
+        with:
+          repository: quietvoid/mpv-winbuild-cmake
+          ref: vs-placebo-libdovi
+
+      - name: Cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            src_packages
+            build64
+          key: ${{ runner.os }}-build-mycache-vsplacebo-libdovi
+
+      - name: Cache info
+        run: |
+          echo "Cache hit: ${{ steps.cache.outputs.cache-hit }}"
+
+      - name: Downloading source
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run: |
+          cmake -DTARGET_ARCH=x86_64-w64-mingw32 -DALWAYS_REMOVE_BUILDFILES=ON -DSINGLE_SOURCE_LOCATION=$PWD/src_packages -G Ninja -Bbuild64 -H.
+          ninja -C build64 download || true
+
+      - name: Building toolchain
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        id: build_toolchain
+        continue-on-error: true
+        run: |
+          if [[ ! "$(ls -A build64/install/bin)" ]]; then ninja -C build64 gcc; fi
+
+      - name: Update dependencies
+        id: update_deps
+        continue-on-error: true
+        run: |
+          ninja -C build64 update
+
+      - name: Building vs-placebo
+        id: build_vs_placebo
+        if: ${{ steps.cache.outputs.cache-hit == 'true' || steps.build_toolchain.outcome == 'success' }}
+        continue-on-error: true
+        run: |
+          ninja -C build64 vs-placebo
+
+      - name: Packaging vs-placebo
+        id: packaging_vs_placebo
+        if: ${{ steps.build_vs_placebo.outcome == 'success' }}
+        continue-on-error: true
+        run: |
+          mkdir -p release
+          mv build64/install/x86_64-w64-mingw32/lib64/vapoursynth/libvs_placebo.dll .
+          7z a ./release/libvs_placebo.zip libvs_placebo.dll
+          rm -f ./libvs_placebo.dll
+
+      - name: Uploading release
+        id: uploading_release
+        if: ${{ steps.packaging_vs_placebo.outcome == 'success' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: vs-placebo
+          path: release
+
+      - name: Collecting logs
+        id: collect_logs
+        run: |
+          mkdir -p build64_logs
+          cp -fr $(find build64 -type f -iname "*-*.log") build64_logs || true
+          7z a -m0=lzma2 -mx=9 -ms=on logs.7z build*logs
+
+      - name: Uploading logs
+        id: upload_logs
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs
+          path: logs.7z
+          retention-days: 1
+
+      - name: Cleaning build directory
+        id: delete_build_dir
+        run: |
+          ninja -C build64 clean
+          du -sh build64 src_packages /var/cache/pacman/pkg || true

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ For example, to map from [BT.2020, PQ] (HDR) to traditional [BT.709, BT.1886] (S
 For Dolby Vision support, FFmpeg 5.0 minimum and git ffms2 are required, as well as libplacebo v4.157.0.185 or newer.  
 Currently, [libdovi](https://github.com/quietvoid/dovi_tool/tree/main/dolby_vision) is required.
 
+For Windows, `libdovi` is available as a [precompiled DLL](https://github.com/quietvoid/dovi_tool/releases/tag/libdovi-1.6.3).  
+The library must be placed in the same directory as `vs-placebo` and be named `dovi.dll`.
+
 &nbsp;
 
 #### ``placebo.Resample(clip clip[, int width, int height, string filter = "ewa_lanczos", float radius, float clamp, float taper, float blur, float param1, float param2, float sx = 0.0, float sy = 0.0, float antiring = 0.0, int lut_entries = 64, float cutoff = 0.001, bool sigmoidize = 1, bool linearize = 1, float sigmoid_center = 0.75, float sigmoid_slope = 6.5, int trc = 1])``
@@ -112,5 +115,5 @@ Otherwise it's as simple as `DESTDIR= ninja -C build install`.
 &nbsp;
 
 Building on Linux for Windows:  
-Some experimental build system based on `mpv-winbuild-cmake`: https://github.com/quietvoid/mpv-winbuild-cmake/commits/vs-placebo-winbuild  
-YMMV.
+Some experimental build system based on `mpv-winbuild-cmake`: https://github.com/quietvoid/mpv-winbuild-cmake/commits/vs-placebo-libdovi  
+Suggested to use on Arch Linux. YMMV.

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('vs-placebo', ['c', 'cpp'],
-  default_options: ['buildtype=release', 'b_ndebug=if-release', 'c_std=c99', 'cpp_std=c++11'],
-  meson_version: '>=0.46.0',
+  default_options: ['buildtype=release', 'b_ndebug=if-release', 'c_std=c11', 'cpp_std=c++11'],
+  meson_version: '>=0.51.0',
   version: '1.4.1'
 )
 
@@ -8,9 +8,15 @@ win32 = host_machine.system() == 'windows' or host_machine.system() == 'cgywin'
 
 placebo = dependency('libplacebo', required: true, static: win32)
 vapoursynth_dep = dependency('vapoursynth', static: win32).partial_dependency(includes: true, compile_args: true)
-dovi = dependency('dovi', required: false)
 
-use_dovi = not win32 and dovi.found()
+if win32
+  cc = meson.get_compiler('c')
+  dovi = cc.find_library('dovi', required : false)
+else
+  dovi = dependency('dovi', required: false)
+endif
+
+use_dovi = dovi.found()
 
 config_vsplacebo = configuration_data()
 config_vsplacebo.set('HAVE_DOVI', use_dovi)


### PR DESCRIPTION
Requires the lib DLL to work at all

Will add a GH Action for building, and make a precompiled `libdovi` DLL available later.