### PR TITLE
Implement libplacebo per-scene tone mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 
 &nbsp;
 
-#### ``placebo.Deband(clip clip[, int planes = 1, int iterations = 1, float threshold = 4.0, float radius = 16.0, float grain = 6.0, int dither = True, int dither_algo = 0])``
+#### `placebo.Deband(clip clip[, int planes = 1, int iterations = 1, float threshold = 4.0, float radius = 16.0, float grain = 6.0, int dither = True, int dither_algo = 0])`
 
 Input needs to be 8 or 16 bit Integer or 32 bit Float.
 
-- ``planes``: the planes to filter. The n-th plane is processed if the n-th lowest bit of ``planes`` is 1, so for example to filter all planes, pass ``planes = 1 | 2 | 4`` .
+- `planes`: the planes to filter. The n-th plane is processed if the n-th lowest bit of `planes` is 1, so for example to filter all planes, pass `planes = 1 | 2 | 4` .
 (Yes, this is needlessly complex, but it was the simplest to implement.)
 
-- ``dither``: whether the debanded frame should be dithered or rounded from float to the output bitdepth. Only works for 8 bit.
+- `dither`: whether the debanded frame should be dithered or rounded from float to the output bitdepth. Only works for 8 bit.
 
 For details on the [debanding params](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/shaders/sampling.h#L39)
 and the [dither methods](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/shaders/colorspace.h#L275),
@@ -18,51 +18,58 @@ see the libplacebo header files.
 
 &nbsp;
 
-#### ``placebo.Tonemap(clip clip[, int src_csp, int dst_csp, int dst_prim, float src_max, float src_min, float dst_max, float dst_min, int dynamic_peak_detection, float smoothing_period, float scene_threshold_low, scene_threshold_high, int intent, int gamut_mode, int tone_mapping_function, int tone_mapping_mode, float tone_mapping_param, float tone_mapping_crosstalk, bool use_dovi])``
+#### `placebo.Tonemap(clip clip[, int src_csp, int dst_csp, int dst_prim, float src_max, float src_min, float dst_max, float dst_min, int dynamic_peak_detection, float smoothing_period, float scene_threshold_low, scene_threshold_high, int intent, int gamut_mode, int tone_mapping_function, int tone_mapping_mode, float tone_mapping_param, float tone_mapping_crosstalk, bool use_dovi, float[] scene_max, float scene_avg])`
 
 Performs color mapping (which includes tonemapping from HDR to SDR, but can do a lot more).  
 Expects RGB48 or YUVxxxP16 input.  
 Outputs RGB48 or YUV444P16, depending on input color family.
 
-- ``src_csp, dst_csp``:  
+- `src_csp, dst_csp`:  
 See the `supported_colorspace` in `tonemap.c` for the valid src/dst colorspaces.  
-For example, to map from [BT.2020, PQ] (HDR) to traditional [BT.709, BT.1886] (SDR), pass ``src_csp=1, dst_csp=0``.
-- ``dst_prim``: Target color primaries. See [pl_color_primaries](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/colorspace.h#L193) for valid values.
-- ``src_max, src_min, dst_max, dst_min``: Source/target display levels, in nits (cd/m^2). Source can be derived from props if available.
+For example, to map from [BT.2020, PQ] (HDR) to traditional [BT.709, BT.1886] (SDR), pass `src_csp=1, dst_csp=0`.
+- `dst_prim`: Target color primaries. See [pl_color_primaries](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/colorspace.h#L193) for valid values.
+- `src_max, src_min, dst_max, dst_min`: Source/target display levels, in nits (cd/m^2). Source can be derived from props if available.
 
-- ``dynamic_peak_detection``: enables computation of signal stats to optimize HDR tonemapping quality. Enabled by default.
-- ``smoothing_period, scene_threshold_low, scene_threshold_high``: peak detection params. See [here](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/shaders/colorspace.h#L85).
-- ``gamut_mode, tone_mapping_function, tone_mapping_mode, tone_mapping_param, tone_mapping_crosstalk``:
+- `dynamic_peak_detection`: enables computation of signal stats to optimize HDR tonemapping quality. Enabled by default.
+- `smoothing_period, scene_threshold_low, scene_threshold_high`: peak detection params. See [here](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/shaders/colorspace.h#L85).
+- `gamut_mode, tone_mapping_function, tone_mapping_mode, tone_mapping_param, tone_mapping_crosstalk`:
  [Color mapping params](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/shaders/colorspace.h#L237).
-- ``use_dovi``: Whether to use the Dolby Vision RPU for ST2086 metadata. Defaults to true when tonemapping from Dolby Vision.
+- `tone_mapping_function_s`: Tone mapping function name, overwrites `tone_mapping_function` number.
+- `use_dovi`: Whether to use the Dolby Vision RPU for ST2086 metadata. Defaults to true when tonemapping from Dolby Vision.
 
-For Dolby Vision support, FFmpeg 5.0 minimum and git ffms2 are required, as well as libplacebo v4.157.0.185 or newer.  
-Currently, [libdovi](https://github.com/quietvoid/dovi_tool/tree/main/dolby_vision) is required.
-
-For Windows, `libdovi` is available as a [precompiled DLL](https://github.com/quietvoid/dovi_tool/releases/tag/libdovi-1.6.7).  
-The library must be placed in the same directory as `vs-placebo` and be named `dovi.dll`.
+For Dolby Vision support, FFmpeg 5.0 minimum and git ffms2 are required.
 
 &nbsp;
 
-#### ``placebo.Resample(clip clip[, int width, int height, string filter = "ewa_lanczos", float radius, float clamp, float taper, float blur, float param1, float param2, float sx = 0.0, float sy = 0.0, float antiring = 0.0, int lut_entries = 64, float cutoff = 0.001, bool sigmoidize = 1, bool linearize = 1, float sigmoid_center = 0.75, float sigmoid_slope = 6.5, int trc = 1])``
+**Supported frame props**
+- `PLSceneMax`, `PLSceneAvg`: Per-scene dynamic brightness metadata, in nits (cd/m^2).
+    - `float[] PLSceneMax`: the scene's peak brightness. Can be specified by component (RGB) or a single value.
+    - `float PLSceneAvg`: the scene's average brightness.
+
+    Requires `libplacebo` v5.246.0 or newer, otherwise ignored.  
+    If `use_dovi` is enabled, `scene_max` and `scene_avg` are derived from the Dolby Vision RPU L1 metadata instead of the props.
+
+&nbsp;
+
+#### `placebo.Resample(clip clip[, int width, int height, string filter = "ewa_lanczos", float radius, float clamp, float taper, float blur, float param1, float param2, float sx = 0.0, float sy = 0.0, float antiring = 0.0, int lut_entries = 64, float cutoff = 0.001, bool sigmoidize = 1, bool linearize = 1, float sigmoid_center = 0.75, float sigmoid_slope = 6.5, int trc = 1])`
 
 Input needs to be 8 or 16 bit Integer or 32 bit Float   
 
-- ``filter``: See [the header](https://github.com/haasn/libplacebo/blob/210131146739e4e84d689f32c17a97b27a6550bd/src/include/libplacebo/filters.h#L187) for possible values (remove the “pl_filter” before the filter name, e.g. ``filter="lanczos"``).  
-- ``sx``, ``sy``: Top left corner of the source region. Can be used for subpixel shifts
-- ``clamp, taper, blur``: [Filter config](https://github.com/haasn/libplacebo/blob/885e89bccfb932d9e8c8659039ab6975e885e996/src/include/libplacebo/filters.h#L148).
+- `filter`: See [the header](https://github.com/haasn/libplacebo/blob/210131146739e4e84d689f32c17a97b27a6550bd/src/include/libplacebo/filters.h#L187) for possible values (remove the “pl_filter” before the filter name, e.g. `filter="lanczos"`).  
+- `sx`, `sy`: Top left corner of the source region. Can be used for subpixel shifts
+- `clamp, taper, blur`: [Filter config](https://github.com/haasn/libplacebo/blob/885e89bccfb932d9e8c8659039ab6975e885e996/src/include/libplacebo/filters.h#L148).
 
-- ``radius, param1, param2``: [Kernel config](https://github.com/haasn/libplacebo/blob/885e89bccfb932d9e8c8659039ab6975e885e996/src/include/libplacebo/filters.h#L30-L131).
-- ``sigmoidize, linearize``: Whether to linearize/sigmoidize before scaling.
+- `radius, param1, param2`: [Kernel config](https://github.com/haasn/libplacebo/blob/885e89bccfb932d9e8c8659039ab6975e885e996/src/include/libplacebo/filters.h#L30-L131).
+- `sigmoidize, linearize`: Whether to linearize/sigmoidize before scaling.
 Enabled by default for RGB, disabled for YCbCr because NCL YCbCr can’t be correctly linearized without conversion to RGB.
 Defaults to disabled for GRAY since it may be a YCbCr plane, but can be manually enabled. 
-When sigmodizing, ``linearize`` should be True as well. (Currently mangles HDR video, so disable for that.) 
-- ``sigmoid_center, sigmoid_slope``: Sigmoid curve parameters.
-- ``trc``: The [transfer curve](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/colorspace.h#L183) to use for linearizing.
+When sigmodizing, `linearize` should be True as well. (Currently mangles HDR video, so disable for that.) 
+- `sigmoid_center, sigmoid_slope`: Sigmoid curve parameters.
+- `trc`: The [transfer curve](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/colorspace.h#L183) to use for linearizing.
 
 &nbsp;
 
-#### ``placebo.Shader(clip clip, [string shader, int width, int height, int chroma_loc = 1, int matrix = 2, int trc = 1, string filter = "ewa_lanczos", float radius, float clamp, float taper, float blur, float param1, float param2, float antiring = 0.0, int lut_entries = 64, float cutoff = 0.001, bool sigmoidize = 1, bool linearize = 1, float sigmoid_center = 0.75, float sigmoid_slope = 6.5, string shader_s])``
+#### `placebo.Shader(clip clip, [string shader, int width, int height, int chroma_loc = 1, int matrix = 2, int trc = 1, string filter = "ewa_lanczos", float radius, float clamp, float taper, float blur, float param1, float param2, float antiring = 0.0, int lut_entries = 64, float cutoff = 0.001, bool sigmoidize = 1, bool linearize = 1, float sigmoid_center = 0.75, float sigmoid_slope = 6.5, string shader_s])`
 
 Runs a GLSL shader in [mpv syntax](https://mpv.io/manual/master/#options-glsl-shader).
 
@@ -74,18 +81,18 @@ As such, the user needs to specify the output frame properties,
 and libplacebo will produce a conforming image,
 only running the supplied shader if the texture it hooks into is actually rendered.
 For example, if a shader hooks into the LINEAR texture,
-it will only be executed when ``linearize = True``. 
+it will only be executed when `linearize = True`. 
 
-- ``shader``: Path to shader file.
-- ``shader_s``: Alternatively, String containing the shader. (``shader`` takes precedence.)
-- ``width, height``: Output dimensions. Need to be specified for scaling shaders to be run. 
+- `shader`: Path to shader file.
+- `shader_s`: Alternatively, String containing the shader. (`shader` takes precedence.)
+- `width, height`: Output dimensions. Need to be specified for scaling shaders to be run. 
 Any planes the shader doesn’t scale appropiately will be scaled to output res by libplacebo
-using the supplied filter options, which are identical to ``Resample``’s.
+using the supplied filter options, which are identical to `Resample`’s.
 (To be exact, chroma will be scaled to what the luma prescaler outputs
 (or the source luma res); then the image will be scaled to output res in RGB and converted back to YUV.)
-- ``chroma_loc``: Chroma location to derive chroma shift from. Uses [pl_chroma_location](https://github.com/haasn/libplacebo/blob/524e3965c6f8f976b3f8d7d82afe3083d61a7c4d/src/include/libplacebo/colorspace.h#L332) enum values.
-- ``matrix``: [YUV matrix](https://github.com/haasn/libplacebo/blob/524e3965c6f8f976b3f8d7d82afe3083d61a7c4d/src/include/libplacebo/colorspace.h#L26).
-- ``sigmoidize, linearize, sigmoid_center, sigmoid_slope, trc``: For shaders that hook into the LINEAR or SIGMOID texture.
+- `chroma_loc`: Chroma location to derive chroma shift from. Uses [pl_chroma_location](https://github.com/haasn/libplacebo/blob/524e3965c6f8f976b3f8d7d82afe3083d61a7c4d/src/include/libplacebo/colorspace.h#L332) enum values.
+- `matrix`: [YUV matrix](https://github.com/haasn/libplacebo/blob/524e3965c6f8f976b3f8d7d82afe3083d61a7c4d/src/include/libplacebo/colorspace.h#L26).
+- `sigmoidize, linearize, sigmoid_center, sigmoid_slope, trc`: For shaders that hook into the LINEAR or SIGMOID texture.
 
 &nbsp;
 

--- a/src/dovi_meta.h
+++ b/src/dovi_meta.h
@@ -2,136 +2,135 @@
 
 #include <libplacebo/colorspace.h>
 
-#if PL_API_VER >= 185
-    #ifdef HAVE_DOVI
-        #include "libdovi/rpu_parser.h"
+#ifdef HAVE_DOVI
+#include <libdovi/rpu_parser.h>
 
-        static struct pl_dovi_metadata *create_dovi_meta(DoviRpuOpaque *rpu,
-                                                        const DoviRpuDataHeader *hdr)
-        {
-            static struct pl_dovi_metadata dovi_meta; // persist state
-            if (hdr->use_prev_vdr_rpu_flag)
-                goto done;
+static struct pl_dovi_metadata *create_dovi_meta(DoviRpuOpaque *rpu,
+                                                const DoviRpuDataHeader *hdr)
+{
+    static struct pl_dovi_metadata dovi_meta; // persist state
+    if (hdr->use_prev_vdr_rpu_flag)
+        goto done;
 
-            const DoviRpuDataMapping *mapping = dovi_rpu_get_data_mapping(rpu);
-            if (!mapping)
-                goto skip_mapping;
+    const DoviRpuDataMapping *mapping = dovi_rpu_get_data_mapping(rpu);
+    if (!mapping)
+        goto skip_mapping;
 
-            const uint8_t bits = hdr->bl_bit_depth_minus8 + 8;
-            const float scale = 1.0f / (1 << hdr->coefficient_log2_denom);
+    const uint8_t bits = hdr->bl_bit_depth_minus8 + 8;
+    const float scale = 1.0f / (1 << hdr->coefficient_log2_denom);
 
-        #if RPU_PARSER_MAJOR >= 3
-            for (int c = 0; c < 3; c++) {
-                const DoviReshapingCurve curve = mapping->curves[c];
+#if RPU_PARSER_MAJOR >= 3
+    for (int c = 0; c < 3; c++) {
+        const DoviReshapingCurve curve = mapping->curves[c];
 
-                struct pl_reshape_data *cmp = &dovi_meta.comp[c];
-                cmp->num_pivots = curve.pivots.len;
-                memset(cmp->method, curve.mapping_idc, sizeof(cmp->method));
+        struct pl_reshape_data *cmp = &dovi_meta.comp[c];
+        cmp->num_pivots = curve.pivots.len;
+        memset(cmp->method, curve.mapping_idc, sizeof(cmp->method));
 
-                uint16_t pivot = 0;
-                for (int pivot_idx = 0; pivot_idx < cmp->num_pivots; pivot_idx++) {
-                    pivot += curve.pivots.data[pivot_idx];
-                    cmp->pivots[pivot_idx] = (float) pivot / ((1 << bits) - 1);
-                }
-
-                for (int i = 0; i < cmp->num_pivots - 1; i++) {
-                    memset(cmp->poly_coeffs[i], 0, sizeof(cmp->poly_coeffs[i]));
-
-                    if (curve.polynomial) {
-                        const DoviPolynomialCurve *poly_curve = curve.polynomial;
-
-                        for (int k = 0; k <= poly_curve->poly_order_minus1.data[i] + 1; k++) {
-                            int64_t ipart = poly_curve->poly_coef_int.list[i]->data[k];
-                            uint64_t fpart = poly_curve->poly_coef.list[i]->data[k];
-                            cmp->poly_coeffs[i][k] = ipart + scale * fpart;
-                        }
-                    } else if (curve.mmr) {
-                        const DoviMMRCurve *mmr_curve = curve.mmr;
-
-                        int64_t ipart = mmr_curve->mmr_constant_int.data[i];
-                        uint64_t fpart = mmr_curve->mmr_constant.data[i];
-                        cmp->mmr_constant[i] = ipart + scale * fpart;
-                        cmp->mmr_order[i] = mmr_curve->mmr_order_minus1.data[i] + 1;
-
-                        for (int j = 0; j < cmp->mmr_order[i]; j++) {
-                            for (int k = 0; k < 7; k++) {
-                                ipart = mmr_curve->mmr_coef_int.list[i]->list[j]->data[k];
-                                fpart = mmr_curve->mmr_coef.list[i]->list[j]->data[k];
-                                cmp->mmr_coeffs[i][j][k] = ipart + scale * fpart;
-                            }
-                        }
-                    }
-                }
-            }
-        #else
-            for (int c = 0; c < 3; c++) {
-                struct pl_reshape_data *cmp = &dovi_meta.comp[c];
-                uint16_t pivot = 0;
-                cmp->num_pivots = hdr->num_pivots_minus_2[c] + 2;
-                for (int pivot_idx = 0; pivot_idx < cmp->num_pivots; pivot_idx++) {
-                    pivot += hdr->pred_pivot_value[c].data[pivot_idx];
-                    cmp->pivots[pivot_idx] = (float) pivot / ((1 << bits) - 1);
-                }
-
-                for (int i = 0; i < cmp->num_pivots - 1; i++) {
-                    memset(cmp->poly_coeffs[i], 0, sizeof(cmp->poly_coeffs[i]));
-                    cmp->method[i] = mapping->mapping_idc[c].data[i];
-
-                    switch (cmp->method[i]) {
-                    case 0: // polynomial
-                        for (int k = 0; k <= mapping->poly_order_minus1[c].data[i] + 1; k++) {
-                            int64_t ipart = mapping->poly_coef_int[c].list[i]->data[k];
-                            uint64_t fpart = mapping->poly_coef[c].list[i]->data[k];
-                            cmp->poly_coeffs[i][k] = ipart + scale * fpart;
-                        }
-                        break;
-                    case 1: // MMR
-                        int64_t ipart = mapping->mmr_constant_int[c].data[i];
-                        uint64_t fpart = mapping->mmr_constant[c].data[i];
-                        cmp->mmr_constant[i] = ipart + scale * fpart;
-                        cmp->mmr_order[i] = mapping->mmr_order_minus1[c].data[i] + 1;
-                        for (int j = 1; j <= cmp->mmr_order[i]; j++) {
-                            for (int k = 0; k < 7; k++) {
-                                ipart = mapping->mmr_coef_int[c].list[i]->list[j]->data[k];
-                                fpart = mapping->mmr_coef[c].list[i]->list[j]->data[k];
-                                cmp->mmr_coeffs[i][j - 1][k] = ipart + scale * fpart;
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
-        #endif
-
-            dovi_rpu_free_data_mapping(mapping);
-        skip_mapping:
-
-            if (hdr->vdr_dm_metadata_present_flag) {
-                const DoviVdrDmData *dm_data = dovi_rpu_get_vdr_dm_data(rpu);
-                if (!dm_data)
-                    goto done;
-
-                const uint32_t *off = &dm_data->ycc_to_rgb_offset0;
-                for (int i = 0; i < 3; i++)
-                    dovi_meta.nonlinear_offset[i] = (float) off[i] / (1 << 28);
-
-                const int16_t *src = &dm_data->ycc_to_rgb_coef0;
-                float *dst = &dovi_meta.nonlinear.m[0][0];
-                for (int i = 0; i < 9; i++)
-                    dst[i] = src[i] / 8192.0;
-
-                src = &dm_data->rgb_to_lms_coef0;
-                dst = &dovi_meta.linear.m[0][0];
-                for (int i = 0; i < 9; i++)
-                    dst[i] = src[i] / 16384.0;
-
-                dovi_rpu_free_vdr_dm_data(dm_data);
-            }
-
-        done: ;
-            struct pl_dovi_metadata *ret = malloc(sizeof(dovi_meta));
-            memcpy(ret, &dovi_meta, sizeof(dovi_meta));
-            return ret;
+        uint16_t pivot = 0;
+        for (int pivot_idx = 0; pivot_idx < cmp->num_pivots; pivot_idx++) {
+            pivot += curve.pivots.data[pivot_idx];
+            cmp->pivots[pivot_idx] = (float) pivot / ((1 << bits) - 1);
         }
-    #endif
+
+        for (int i = 0; i < cmp->num_pivots - 1; i++) {
+            memset(cmp->poly_coeffs[i], 0, sizeof(cmp->poly_coeffs[i]));
+
+            if (curve.polynomial) {
+                const DoviPolynomialCurve *poly_curve = curve.polynomial;
+
+                for (int k = 0; k <= poly_curve->poly_order_minus1.data[i] + 1; k++) {
+                    int64_t ipart = poly_curve->poly_coef_int.list[i]->data[k];
+                    uint64_t fpart = poly_curve->poly_coef.list[i]->data[k];
+                    cmp->poly_coeffs[i][k] = ipart + scale * fpart;
+                }
+            } else if (curve.mmr) {
+                const DoviMMRCurve *mmr_curve = curve.mmr;
+
+                int64_t ipart = mmr_curve->mmr_constant_int.data[i];
+                uint64_t fpart = mmr_curve->mmr_constant.data[i];
+                cmp->mmr_constant[i] = ipart + scale * fpart;
+                cmp->mmr_order[i] = mmr_curve->mmr_order_minus1.data[i] + 1;
+
+                for (int j = 0; j < cmp->mmr_order[i]; j++) {
+                    for (int k = 0; k < 7; k++) {
+                        ipart = mmr_curve->mmr_coef_int.list[i]->list[j]->data[k];
+                        fpart = mmr_curve->mmr_coef.list[i]->list[j]->data[k];
+                        cmp->mmr_coeffs[i][j][k] = ipart + scale * fpart;
+                    }
+                }
+            }
+        }
+    }
+#else
+    for (int c = 0; c < 3; c++) {
+        struct pl_reshape_data *cmp = &dovi_meta.comp[c];
+        uint16_t pivot = 0;
+        cmp->num_pivots = hdr->num_pivots_minus_2[c] + 2;
+        for (int pivot_idx = 0; pivot_idx < cmp->num_pivots; pivot_idx++) {
+            pivot += hdr->pred_pivot_value[c].data[pivot_idx];
+            cmp->pivots[pivot_idx] = (float) pivot / ((1 << bits) - 1);
+        }
+
+        for (int i = 0; i < cmp->num_pivots - 1; i++) {
+            memset(cmp->poly_coeffs[i], 0, sizeof(cmp->poly_coeffs[i]));
+            cmp->method[i] = mapping->mapping_idc[c].data[i];
+
+            switch (cmp->method[i]) {
+            case 0: // polynomial
+                for (int k = 0; k <= mapping->poly_order_minus1[c].data[i] + 1; k++) {
+                    int64_t ipart = mapping->poly_coef_int[c].list[i]->data[k];
+                    uint64_t fpart = mapping->poly_coef[c].list[i]->data[k];
+                    cmp->poly_coeffs[i][k] = ipart + scale * fpart;
+                }
+                break;
+            case 1: // MMR
+                int64_t ipart = mapping->mmr_constant_int[c].data[i];
+                uint64_t fpart = mapping->mmr_constant[c].data[i];
+                cmp->mmr_constant[i] = ipart + scale * fpart;
+                cmp->mmr_order[i] = mapping->mmr_order_minus1[c].data[i] + 1;
+                for (int j = 1; j <= cmp->mmr_order[i]; j++) {
+                    for (int k = 0; k < 7; k++) {
+                        ipart = mapping->mmr_coef_int[c].list[i]->list[j]->data[k];
+                        fpart = mapping->mmr_coef[c].list[i]->list[j]->data[k];
+                        cmp->mmr_coeffs[i][j - 1][k] = ipart + scale * fpart;
+                    }
+                }
+                break;
+            }
+        }
+    }
 #endif
+
+    dovi_rpu_free_data_mapping(mapping);
+skip_mapping:
+
+    if (hdr->vdr_dm_metadata_present_flag) {
+        const DoviVdrDmData *dm_data = dovi_rpu_get_vdr_dm_data(rpu);
+        if (!dm_data)
+            goto done;
+
+        const uint32_t *off = &dm_data->ycc_to_rgb_offset0;
+        for (int i = 0; i < 3; i++)
+            dovi_meta.nonlinear_offset[i] = (float) off[i] / (1 << 28);
+
+        const int16_t *src = &dm_data->ycc_to_rgb_coef0;
+        float *dst = &dovi_meta.nonlinear.m[0][0];
+        for (int i = 0; i < 9; i++)
+            dst[i] = src[i] / 8192.0;
+
+        src = &dm_data->rgb_to_lms_coef0;
+        dst = &dovi_meta.linear.m[0][0];
+        for (int i = 0; i < 9; i++)
+            dst[i] = src[i] / 16384.0;
+
+        dovi_rpu_free_vdr_dm_data(dm_data);
+    }
+
+done: ;
+    struct pl_dovi_metadata *ret = malloc(sizeof(dovi_meta));
+    memcpy(ret, &dovi_meta, sizeof(dovi_meta));
+    return ret;
+}
+
+#endif // HAVE_DOVI

--- a/src/vs-placebo.c
+++ b/src/vs-placebo.c
@@ -96,7 +96,8 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(VSConfigPlugin configFunc, VSRegiste
                             "scene_threshold_low:float:opt;scene_threshold_high:float:opt;"
                             "intent:int:opt;"
                             "gamut_mode:int:opt;"
-                            "tone_mapping_function:int:opt;tone_mapping_mode:int:opt;"
+                            "tone_mapping_function:int:opt;tone_mapping_function_s:data:opt;"
+                            "tone_mapping_mode:int:opt;"
                             "tone_mapping_param:float:opt;tone_mapping_crosstalk:float:opt;"
                             "use_dovi:int:opt;"
                             "log_level:int:opt;", VSPlaceboTMCreate, 0, plugin);


### PR DESCRIPTION
The best way is to use frame props, because varying filter arguments constantly recreates the filter context and that's bad.
Waiting on https://code.videolan.org/videolan/libplacebo/-/merge_requests/360.