### PR TITLE
Get windows build action working and update libplacebo

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,97 +1,59 @@
-defaults:
-  run:
-    shell: bash
+name: windows build
 
 on:
   workflow_dispatch:
-
-name: vs-placebo build
+  push:
+    branches:
+      - main
 
 jobs:
-  build_vs_placebo:
-    name: Building vs-placebo
-    runs-on: ubuntu-latest
-    env:
-      CURL_RETRIES: "--connect-timeout 60 --retry 999 --retry-delay 5 --retry-all-errors"
-    container:
-      image: docker://archlinux:base-devel
-
+  build-windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
-      - name: Get current date and random hash
-        run: |
-          echo "short_date=$(date "+%Y%m%d")" >> $GITHUB_ENV
-          echo "random_hash=$(echo $RANDOM | md5sum | head -c 20)" >> $GITHUB_ENV
-
-      - name: Installing dependencies
-        run: |
-          echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
-          pacman -Syu --noconfirm
-          pacman -S --noconfirm --needed git gyp mercurial subversion ninja cmake meson \
-            ragel yasm nasm asciidoc enca gperf unzip p7zip gcc-multilib clang \
-            python-pip curl openssl
-
-          pip3 install rst2pdf mako jsonschema
-          git config --global user.name "github-actions"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global --add safe.directory $PWD
-
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          repository: quietvoid/mpv-winbuild-cmake
-          ref: vs-placebo-libdovi
-
-      - name: Downloading source
+          submodules: recursive
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-ucrt-x86_64-jq
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-pkg-config
+            mingw-w64-ucrt-x86_64-vapoursynth
+            mingw-w64-ucrt-x86_64-meson
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-spirv-tools
+            mingw-w64-ucrt-x86_64-spirv-cross
+            mingw-w64-ucrt-x86_64-vulkan
+            mingw-w64-ucrt-x86_64-vulkan-headers
+            mingw-w64-ucrt-x86_64-vulkan-loader
+            mingw-w64-ucrt-x86_64-libdovi
+            mingw-w64-ucrt-x86_64-lcms2
+            mingw-w64-ucrt-x86_64-shaderc
+      - name: Build libplacebo
+        working-directory: ./libplacebo
         run: |
-          cmake -DTARGET_ARCH=x86_64-w64-mingw32 -DALWAYS_REMOVE_BUILDFILES=ON -DSINGLE_SOURCE_LOCATION=$PWD/src_packages -DRUSTUP_LOCATION=$PWD/install_rustup -G Ninja -Bbuild64 -H.
-          ninja -C build64 download || true
-
-      - name: Building toolchain
-        id: build_toolchain
-        continue-on-error: true
-        run: ninja -C build64 gcc
-
-      - name: Update dependencies
-        id: update_deps
-        continue-on-error: true
+          meson setup build --buildtype release --default-library=static -Ddemos=false -Dprefix=$PWD/install
+          meson compile -vC build
+          meson install -C build
+      - name: Build vs-placebo
         run: |
-          ninja -C build64 update
-
-      - name: Building vs-placebo
-        id: build_vs_placebo
-        if: ${{ steps.build_toolchain.outcome == 'success' }}
-        continue-on-error: true
+          meson setup build --buildtype release
+          meson compile -vC build
+      - name: Export version
         run: |
-          ninja -C build64 vs-placebo
-
-      - name: Packaging vs-placebo
-        id: packaging_vs_placebo
-        if: ${{ steps.build_vs_placebo.outcome == 'success' }}
-        continue-on-error: true
-        run: |
-          mkdir -p release
-          mv build64/install/x86_64-w64-mingw32/lib64/vapoursynth/libvs_placebo.dll .
-          7z a ./release/libvs_placebo.zip libvs_placebo.dll
-          rm -f ./libvs_placebo.dll
-
-      - name: Uploading release
-        id: uploading_release
-        if: ${{ steps.packaging_vs_placebo.outcome == 'success' }}
+          echo "ARTIFACT_VERSION=$(meson introspect --projectinfo build | jq -r '.version')" >> $GITHUB_ENV
+      - name: Upload
         uses: actions/upload-artifact@v3
         with:
-          name: vs-placebo
-          path: release
-
-      - name: Collecting logs
-        if: always()
-        run: |
-          mkdir -p build64_logs
-          cp -fr $(find build64 -type f -iname "*-*.log") build64_logs || true
-          7z a -m0=lzma2 -mx=9 -ms=on logs.7z build*logs
-
-      - name: Uploading logs
-        uses: actions/upload-artifact@master
-        if: always()
-        with:
-          name: logs
-          path: logs.7z
-          retention-days: 1
+          name: vsplacebo-windows-${{ env.ARTIFACT_VERSION }}
+          path: |
+            build/libvs_placebo.dll

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,1 @@
 build/
-libplacebo/
-libplacebo
-cmake-build-release/
-cmake-build-debug/
-vapoursynth
-vapoursynth/
-.vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "libp2p"]
 	path = libp2p
 	url = https://github.com/sekrit-twc/libp2p
+[submodule "libplacebo"]
+	path = libplacebo
+	url = https://github.com/haasn/libplacebo.git
+	ignore = untracked

--- a/meson.build
+++ b/meson.build
@@ -1,14 +1,13 @@
 project('vs-placebo', ['c', 'cpp'],
   default_options: ['buildtype=release', 'b_ndebug=if-release', 'c_std=c11', 'cpp_std=c++11'],
   meson_version: '>=0.51.0',
-  version: '1.4.4'
+  version: '1.4.5'
 )
 
 win32 = host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
 
-placebo = dependency('libplacebo', required: true, version: '>=5.229.0', static: win32)
 vapoursynth_dep = dependency('vapoursynth', static: win32).partial_dependency(includes: true, compile_args: true)
-dovi = dependency('dovi', required: false)
+dovi = dependency('dovi', required: false, static: win32)
 
 use_dovi = dovi.found()
 
@@ -27,9 +26,40 @@ sources = []
 subdir('src')
 
 shared_module('vs_placebo', sources,
-  dependencies: [placebo, vapoursynth_dep, dovi],
+  dependencies: [vapoursynth_dep, dovi],
   link_with: [p2p],
   name_prefix: 'lib',
+  include_directories: [
+    'libplacebo/install/include'
+  ],
+  c_args: [
+    # If this isn't defined then libplacebo headers get preprocessed for dynamic linking
+    '-DPL_STATIC'
+  ],
+  link_args: [
+    '-static',
+    # It's hard to get static links to libplacebo cleanly so just dumping link args here
+    meson.current_source_dir() / 'libplacebo/install/lib/libplacebo.a',
+    '-lm',
+    '-pthread',
+    '-lversion',
+    '-lvulkan-1.dll',
+    '-llcms2',
+    '-llcms2_fast_float',
+    '-lshlwapi',
+    '-lMachineIndependent',
+    '-lOSDependent',
+    '-lGenericCodeGen',
+    '-lOGLCompiler',
+    '-lglslang',
+    '-lSPIRV',
+    '-lSPIRV-Tools-opt',
+    '-lSPIRV-Tools',
+    '-lSPIRV-Tools-link',
+    '-lspirv-cross-glsl',
+    '-lshaderc_combined',
+    '-lspirv-cross-c'
+  ],
   install_dir : join_paths(vapoursynth_dep.get_variable(pkgconfig: 'libdir'), 'vapoursynth'),
   install: true
 )


### PR DESCRIPTION
Moved `libplacebo` to a git submodule (on latest master) and updated the github actions workflow. I don't have strong opinions on the various bits of github action workflow, the changes in this PR are just closer to what I do for local builds so it was easier to write; feel free to tweak.

I have not tested the changes to the `meson.build` on linux at all. I'd be surprised if it didn't break something there. I'm not sure how important having that working is to merging this PR. Also I obviously don't love the link argument spam, but the pkg-config for libplacebo wasn't setup well to get static linking arguments more cleanly. Probably a better solution would be to upstream changes to pkg-config files, but I was more interested in just getting it working for now.