### PR TITLE
Replace deprecated `gamut_mode` and `intent` params

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ see the libplacebo header files.
 
 &nbsp;
 
-#### `placebo.Tonemap(clip clip[, int src_csp, int dst_csp, int dst_prim, float src_max, float src_min, float dst_max, float dst_min, int dynamic_peak_detection, float smoothing_period, float scene_threshold_low, scene_threshold_high, int intent, int gamut_mode, int tone_mapping_function, int tone_mapping_mode, float tone_mapping_param, float tone_mapping_crosstalk, bool use_dovi, bool visualize_lut])`
+#### `placebo.Tonemap(clip clip[, int src_csp, int dst_csp, int dst_prim, float src_max, float src_min, float dst_max, float dst_min, int dynamic_peak_detection, float smoothing_period, float scene_threshold_low, scene_threshold_high, int intent, int tone_mapping_function, int tone_mapping_mode, float tone_mapping_param, float tone_mapping_crosstalk, bool use_dovi, bool visualize_lut])`
 
 Performs color mapping (which includes tonemapping from HDR to SDR, but can do a lot more).  
 Expects RGB48 or YUVxxxP16 input.  
@@ -33,7 +33,7 @@ For example, to map from [BT.2020, PQ] (HDR) to traditional [BT.709, BT.1886] (S
 - `dynamic_peak_detection`: enables computation of signal stats to optimize HDR tonemapping quality. Enabled by default.
 - `smoothing_period, scene_threshold_low, scene_threshold_high, percentile`: peak detection params. See [here](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/shaders/colorspace.h#L103).
     - `percentile` only in v5.264.0+.
-- `gamut_mode, tone_mapping_function, tone_mapping_mode, tone_mapping_param, tone_mapping_crosstalk, metadata`:
+- `tone_mapping_function, tone_mapping_mode, tone_mapping_param, tone_mapping_crosstalk, metadata`:
  [Color mapping params](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/shaders/colorspace.h#L261).
 - `tone_mapping_function_s`: Tone mapping function name, overwrites `tone_mapping_function` number.
 - `use_dovi`: Whether to use the Dolby Vision RPU for ST2086 metadata. Defaults to true when tonemapping from Dolby Vision.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ see the libplacebo header files.
 
 &nbsp;
 
-#### `placebo.Tonemap(clip clip[, int src_csp, int dst_csp, int dst_prim, float src_max, float src_min, float dst_max, float dst_min, int dynamic_peak_detection, float smoothing_period, float scene_threshold_low, scene_threshold_high, int intent, int tone_mapping_function, int tone_mapping_mode, float tone_mapping_param, float tone_mapping_crosstalk, bool use_dovi, bool visualize_lut])`
+#### `placebo.Tonemap(clip clip[, int src_csp, int dst_csp, int dst_prim, float src_max, float src_min, float dst_max, float dst_min, int dynamic_peak_detection, float smoothing_period, float scene_threshold_low, scene_threshold_high, int tone_mapping_function, int tone_mapping_mode, float tone_mapping_param, float tone_mapping_crosstalk, bool use_dovi, bool visualize_lut])`
 
 Performs color mapping (which includes tonemapping from HDR to SDR, but can do a lot more).  
 Expects RGB48 or YUVxxxP16 input.  

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ see the libplacebo header files.
 
 &nbsp;
 
-#### `placebo.Tonemap(clip clip[, int src_csp, int dst_csp, int dst_prim, float src_max, float src_min, float dst_max, float dst_min, int dynamic_peak_detection, float smoothing_period, float scene_threshold_low, scene_threshold_high, int tone_mapping_function, int tone_mapping_mode, float tone_mapping_param, float tone_mapping_crosstalk, bool use_dovi, bool visualize_lut])`
+#### `placebo.Tonemap(clip clip[, int src_csp, int dst_csp, int dst_prim, float src_max, float src_min, float dst_max, float dst_min, int dynamic_peak_detection, float smoothing_period, float scene_threshold_low, scene_threshold_high, int gamut_mapping, int tone_mapping_function, int tone_mapping_mode, float tone_mapping_param, float tone_mapping_crosstalk, bool use_dovi, bool visualize_lut])`
 
 Performs color mapping (which includes tonemapping from HDR to SDR, but can do a lot more).  
 Expects RGB48 or YUVxxxP16 input.  
@@ -29,10 +29,22 @@ See the `supported_colorspace` in `tonemap.c` for the valid src/dst colorspaces.
 For example, to map from [BT.2020, PQ] (HDR) to traditional [BT.709, BT.1886] (SDR), pass `src_csp=1, dst_csp=0`.
 - `dst_prim`: Target color primaries. See [pl_color_primaries](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/colorspace.h#L193) for valid values.
 - `src_max, src_min, dst_max, dst_min`: Source/target display levels, in nits (cd/m^2). Source can be derived from props if available.
-
 - `dynamic_peak_detection`: enables computation of signal stats to optimize HDR tonemapping quality. Enabled by default.
 - `smoothing_period, scene_threshold_low, scene_threshold_high, percentile`: peak detection params. See [here](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/shaders/colorspace.h#L103).
     - `percentile` only in v5.264.0+.
+- `gamut_mapping`: Gamut mapping function to use to handle out-of-gamut colors,
+including colors which are out-of-gamut as a consequence of tone mapping.
+Defaults to 1 (perceptual). The following options are available:
+    - 0 clip 
+    - 1 perceptual
+    - 2 softclip 
+    - 3 relative
+    - 4 saturation
+    - 5 absolute
+    - 6 desaturate
+    - 7 darken
+    - 8 highlight
+    - 9 linear
 - `tone_mapping_function, tone_mapping_mode, tone_mapping_param, tone_mapping_crosstalk, metadata`:
  [Color mapping params](https://github.com/haasn/libplacebo/blob/master/src/include/libplacebo/shaders/colorspace.h#L261).
 - `tone_mapping_function_s`: Tone mapping function name, overwrites `tone_mapping_function` number.

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project('vs-placebo', ['c', 'cpp'],
 
 win32 = host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
 
-placebo = dependency('libplacebo', required: true, version: '>=5.229.0', static: win32)
+placebo = dependency('libplacebo', required: true, version: '>=6.269.0', static: win32)
 vapoursynth_dep = dependency('vapoursynth', static: win32).partial_dependency(includes: true, compile_args: true)
 dovi = dependency('dovi', required: false)
 

--- a/src/tonemap.c
+++ b/src/tonemap.c
@@ -544,7 +544,6 @@ void VS_CC VSPlaceboTMCreate(const VSMap *in, VSMap *out, void *userData, VSCore
 #define COLORM_PARAM(par, type) colorMapParams->par = vsapi->propGet##type(in, #par, 0, &err); \
         if (err) colorMapParams->par = pl_color_map_default_params.par;
 
-    COLORM_PARAM(intent, Int)
     COLORM_PARAM(tone_mapping_mode, Int)
     COLORM_PARAM(tone_mapping_crosstalk, Float)
 #if PL_API_VER >= 247

--- a/src/tonemap.c
+++ b/src/tonemap.c
@@ -518,6 +518,12 @@ void VS_CC VSPlaceboTMCreate(const VSMap *in, VSMap *out, void *userData, VSCore
     struct pl_color_map_params *colorMapParams = malloc(sizeof(struct pl_color_map_params));
     *colorMapParams = pl_color_map_default_params;
 
+    // Gamut mapping function
+    int64_t gamut_map_index = vsapi->propGetInt(in, "gamut_mapping", 0, &err);
+    if (!err && gamut_map_index >= 0 && gamut_map_index < pl_num_gamut_map_functions) {
+        colorMapParams->gamut_mapping = pl_gamut_map_functions[gamut_map_index];
+    }
+
     // Tone mapping function
     int64_t function_index = vsapi->propGetInt(in, "tone_mapping_function", 0, &err);
 

--- a/src/tonemap.c
+++ b/src/tonemap.c
@@ -545,7 +545,6 @@ void VS_CC VSPlaceboTMCreate(const VSMap *in, VSMap *out, void *userData, VSCore
         if (err) colorMapParams->par = pl_color_map_default_params.par;
 
     COLORM_PARAM(intent, Int)
-    COLORM_PARAM(gamut_mode, Int)
     COLORM_PARAM(tone_mapping_mode, Int)
     COLORM_PARAM(tone_mapping_crosstalk, Float)
 #if PL_API_VER >= 247

--- a/src/vs-placebo.c
+++ b/src/vs-placebo.c
@@ -96,7 +96,6 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(VSConfigPlugin configFunc, VSRegiste
                             "scene_threshold_low:float:opt;scene_threshold_high:float:opt;"
                             "percentile:float:opt;"
                             "intent:int:opt;"
-                            "gamut_mode:int:opt;"
                             "tone_mapping_function:int:opt;tone_mapping_function_s:data:opt;"
                             "tone_mapping_mode:int:opt;"
                             "tone_mapping_param:float:opt;tone_mapping_crosstalk:float:opt;"

--- a/src/vs-placebo.c
+++ b/src/vs-placebo.c
@@ -95,7 +95,6 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(VSConfigPlugin configFunc, VSRegiste
                             "dynamic_peak_detection:int:opt;smoothing_period:float:opt;"
                             "scene_threshold_low:float:opt;scene_threshold_high:float:opt;"
                             "percentile:float:opt;"
-                            "intent:int:opt;"
                             "tone_mapping_function:int:opt;tone_mapping_function_s:data:opt;"
                             "tone_mapping_mode:int:opt;"
                             "tone_mapping_param:float:opt;tone_mapping_crosstalk:float:opt;"

--- a/src/vs-placebo.c
+++ b/src/vs-placebo.c
@@ -95,6 +95,7 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit(VSConfigPlugin configFunc, VSRegiste
                             "dynamic_peak_detection:int:opt;smoothing_period:float:opt;"
                             "scene_threshold_low:float:opt;scene_threshold_high:float:opt;"
                             "percentile:float:opt;"
+                            "gamut_mapping:int:opt;"
                             "tone_mapping_function:int:opt;tone_mapping_function_s:data:opt;"
                             "tone_mapping_mode:int:opt;"
                             "tone_mapping_param:float:opt;tone_mapping_crosstalk:float:opt;"


### PR DESCRIPTION
Replace the `gamut_mode` and `intent` parameters, which were deprecated in libplacebo v6.269, with the new `gamut_mapping` parameter.

Breaking change since this removes parameters.