### PR TITLE
Simplify `filter` function mapping in Resample

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For Dolby Vision support, FFmpeg 5.0 minimum and git ffms2 are required.
 
 Input needs to be 8 or 16 bit Integer or 32 bit Float   
 
-- `filter`: See [the header](https://github.com/haasn/libplacebo/blob/210131146739e4e84d689f32c17a97b27a6550bd/src/include/libplacebo/filters.h#L187) for possible values (remove the “pl_filter” before the filter name, e.g. `filter="lanczos"`).  
+- `filter`: See [the header](https://github.com/haasn/libplacebo/blob/v7.349.0/src/include/libplacebo/filters.h#L268-L299) for possible values (remove the "pl_filter_" before the filter name, e.g. `filter="lanczos"`).  
 - `sx`, `sy`: Top left corner of the source region. Can be used for subpixel shifts
 - `clamp, taper, blur`: [Filter config](https://github.com/haasn/libplacebo/blob/885e89bccfb932d9e8c8659039ab6975e885e996/src/include/libplacebo/filters.h#L148).
 

--- a/src/resample.c
+++ b/src/resample.c
@@ -390,31 +390,15 @@ void VS_CC VSPlaceboResampleCreate(const VSMap *in, VSMap *out, void *useResampl
     sampleFilterParams->antiring = vsapi->propGetFloat(in, "antiring", 0, &err);
 
     const char *filter = vsapi->propGetData(in, "filter", 0, &err);
+    if (err) {
+        vsapi->logMessage(mtWarning, "Unspecified filter... selecting ewa_lanczos.\n");
+        filter = "ewa_lanczos";
+    }
 
-    if (!filter) filter = "ewa_lanczos";
-#define FILTER_ELIF(name) else if (strcmp(filter, #name) == 0) sampleFilterParams->filter = pl_filter_##name;
-    if (strcmp(filter, "spline16") == 0)
-        sampleFilterParams->filter = pl_filter_spline16;
-    FILTER_ELIF(spline36)
-    FILTER_ELIF(spline64)
-    FILTER_ELIF(box)
-    FILTER_ELIF(triangle)
-    FILTER_ELIF(gaussian)
-    FILTER_ELIF(sinc)
-    FILTER_ELIF(lanczos)
-    FILTER_ELIF(ginseng)
-    FILTER_ELIF(ewa_jinc)
-    FILTER_ELIF(ewa_ginseng)
-    FILTER_ELIF(ewa_hann)
-    FILTER_ELIF(bicubic)
-    FILTER_ELIF(catmull_rom)
-    FILTER_ELIF(mitchell)
-    FILTER_ELIF(robidoux)
-    FILTER_ELIF(robidouxsharp)
-    FILTER_ELIF(ewa_robidoux)
-    FILTER_ELIF(ewa_lanczos)
-    FILTER_ELIF(ewa_robidouxsharp)
-    else {
+    const struct pl_filter_config *filter_config = pl_find_filter_config(filter, PL_FILTER_SCALING);
+    if (filter_config) {
+        sampleFilterParams->filter = *filter_config;
+    } else {
         vsapi->logMessage(mtWarning, "Unkown filter... selecting ewa_lanczos.\n");
         sampleFilterParams->filter = pl_filter_ewa_lanczos;
     }


### PR DESCRIPTION
It now uses `pl_find_filter_config` to find the filter config instead of requiring that each filter have its own `else if` branch.