### PR TITLE
Fix Vulkan driver crashes (Access Violation) in multi-instance workflows via fmSerial and global submission lock

### DIFF
--- a/src/deband.c
+++ b/src/deband.c
@@ -16,8 +16,6 @@ typedef struct {
     int dither;
     struct pl_render_params *render_params;
     uint8_t frame_index;
-
-    pthread_mutex_t lock;
 } DebandData;
 
 bool vspl_deband_do_image(DebandData *dbd_data, struct pl_frame *src_img, struct pl_frame *dst_img, const VSAPI *vsapi)
@@ -243,7 +241,6 @@ static void VS_CC VSPlaceboDebandFree(void *instanceData, VSCore *core, const VS
     free((void *) d->render_params->dither_params);
     free((void *) d->render_params->deband_params);
     free(d->render_params);
-    pthread_mutex_destroy(&d->lock);
     free(d);
 }
 
@@ -252,12 +249,6 @@ void VS_CC VSPlaceboDebandCreate(const VSMap *in, VSMap *out, void *userData, VS
     DebandData *data;
     int err;
     enum pl_log_level log_level;
-
-    if (pthread_mutex_init(&d.lock, NULL) != 0)
-    {
-        vsapi->setError(out, "placebo.Deband: mutex init failed!");
-        return;
-    }
 
     log_level = vsapi->propGetInt(in, "log_level", 0, &err);
     if (err)

--- a/src/deband.c
+++ b/src/deband.c
@@ -174,8 +174,6 @@ static const VSFrameRef *VS_CC VSPlaceboDebandGetFrame(int n, int activationReas
         };
         struct pl_frame dst_img = src_img;
 
-        pthread_mutex_lock(&dbd_data->lock); // libplacebo isn’t thread-safe
-
         pthread_mutex_lock(&vspl_vulkan_mutex);
 
         struct priv *p = dbd_data->vf;
@@ -230,8 +228,6 @@ static const VSFrameRef *VS_CC VSPlaceboDebandGetFrame(int n, int activationReas
         }
 
         pthread_mutex_unlock(&vspl_vulkan_mutex);
-
-        pthread_mutex_unlock(&dbd_data->lock);
 
         vsapi->freeFrame(frame);
         return dst;

--- a/src/deband.c
+++ b/src/deband.c
@@ -310,5 +310,5 @@ void VS_CC VSPlaceboDebandCreate(const VSMap *in, VSMap *out, void *userData, VS
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "Deband", VSPlaceboDebandInit, VSPlaceboDebandGetFrame, VSPlaceboDebandFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "Deband", VSPlaceboDebandInit, VSPlaceboDebandGetFrame, VSPlaceboDebandFree, fmSerial, 0, data, core);
 }

--- a/src/deband.c
+++ b/src/deband.c
@@ -176,6 +176,8 @@ static const VSFrameRef *VS_CC VSPlaceboDebandGetFrame(int n, int activationReas
 
         pthread_mutex_lock(&dbd_data->lock); // libplacebo isn’t thread-safe
 
+        pthread_mutex_lock(&vspl_vulkan_mutex);
+
         struct priv *p = dbd_data->vf;
 
         int numPlanes = srcFmt->numPlanes;
@@ -226,6 +228,8 @@ static const VSFrameRef *VS_CC VSPlaceboDebandGetFrame(int n, int activationReas
         if (vspl_deband_do_image(dbd_data, &src_img, &dst_img, vsapi)) {
             vspl_deband_download_planes(dbd_data, vsapi, dst, data, &dst_img);
         }
+
+        pthread_mutex_unlock(&vspl_vulkan_mutex);
 
         pthread_mutex_unlock(&dbd_data->lock);
 

--- a/src/resample.c
+++ b/src/resample.c
@@ -342,7 +342,6 @@ static const VSFrameRef *VS_CC VSPlaceboResampleGetFrame(int n, int activationRe
             const float src_w = shift ? d->src_width / subsampling_w : d->src_width;
             const float src_h = shift ? d->src_height / subsampling_h : d->src_height;
 
-            pthread_mutex_lock(&d->lock);
             pthread_mutex_lock(&vspl_vulkan_mutex);
 
             if (vspl_resample_reconfig(d->vf, &plane, w, h, vsapi)) {
@@ -350,7 +349,6 @@ static const VSFrameRef *VS_CC VSPlaceboResampleGetFrame(int n, int activationRe
             }
 
             pthread_mutex_unlock(&vspl_vulkan_mutex);
-            pthread_mutex_unlock(&d->lock);
         }
 
         const VSMap *src_props = vsapi->getFramePropsRO(frame);

--- a/src/resample.c
+++ b/src/resample.c
@@ -507,5 +507,5 @@ void VS_CC VSPlaceboResampleCreate(const VSMap *in, VSMap *out, void *useResampl
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "Resample", VSPlaceboResampleInit, VSPlaceboResampleGetFrame, VSPlaceboResampleFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "Resample", VSPlaceboResampleInit, VSPlaceboResampleGetFrame, VSPlaceboResampleFree, fmSerial, 0, data, core);
 }

--- a/src/resample.c
+++ b/src/resample.c
@@ -30,7 +30,6 @@ typedef struct {
     struct pl_sigmoid_params *sigmoid_params;
     enum pl_color_transfer trc;
     bool linear;
-    pthread_mutex_t lock;
 } ResampleData;
 
 bool vspl_resample_do_plane(struct priv *p, void *data, int w, int h, float src_width, float src_height, const VSAPI *vsapi, float sx, float sy)
@@ -380,7 +379,6 @@ static void VS_CC VSPlaceboResampleFree(void *instanceData, VSCore *core, const 
     free(d->sampleParams);
     free(d->sigmoid_params);
     VSPlaceboUninit(d->vf);
-    pthread_mutex_destroy(&d->lock);
     free(d);
 }
 
@@ -389,12 +387,6 @@ void VS_CC VSPlaceboResampleCreate(const VSMap *in, VSMap *out, void *useResampl
     ResampleData *data;
     int err;
     enum pl_log_level log_level;
-
-    if (pthread_mutex_init(&d.lock, NULL) != 0)
-    {
-        vsapi->setError(out, "placebo.Resample: mutex init failed\n");
-        return;
-    }
 
     log_level = vsapi->propGetInt(in, "log_level", 0, &err);
     if (err)

--- a/src/resample.c
+++ b/src/resample.c
@@ -343,11 +343,13 @@ static const VSFrameRef *VS_CC VSPlaceboResampleGetFrame(int n, int activationRe
             const float src_h = shift ? d->src_height / subsampling_h : d->src_height;
 
             pthread_mutex_lock(&d->lock);
+            pthread_mutex_lock(&vspl_vulkan_mutex);
 
             if (vspl_resample_reconfig(d->vf, &plane, w, h, vsapi)) {
                 vspl_resample_filter(d->vf, dst, &plane, d, w, h, src_w, src_h, sx, sy, vsapi, i);
             }
 
+            pthread_mutex_unlock(&vspl_vulkan_mutex);
             pthread_mutex_unlock(&d->lock);
         }
 

--- a/src/shader.c
+++ b/src/shader.c
@@ -223,7 +223,6 @@ static const VSFrameRef *VS_CC VSPlaceboShaderGetFrame(int n, int activationReas
 
         void *packed_dst = malloc(d->width * d->height * 2 * 3);
 
-        pthread_mutex_lock(&d->lock);
         pthread_mutex_lock(&vspl_vulkan_mutex);
 
         if (vspl_shader_reconfig(d->vf, planes, vsapi, d)) {
@@ -231,7 +230,6 @@ static const VSFrameRef *VS_CC VSPlaceboShaderGetFrame(int n, int activationReas
         }
 
         pthread_mutex_unlock(&vspl_vulkan_mutex);
-        pthread_mutex_unlock(&d->lock);
 
         struct p2p_buffer_param pack_params = {
             .width = d->width,

--- a/src/shader.c
+++ b/src/shader.c
@@ -27,7 +27,6 @@ typedef  struct {
     struct pl_sigmoid_params *sigmoid_params;
     enum pl_color_transfer trc;
     bool linear;
-    pthread_mutex_t lock;
 } ShaderData;
 
 
@@ -262,7 +261,6 @@ static void VS_CC VSPlaceboShaderFree(void *instanceData, VSCore *core, const VS
     free(d->sampleParams);
     free(d->sigmoid_params);
     VSPlaceboUninit(d->vf);
-    pthread_mutex_destroy(&d->lock);
     free(d);
 }
 
@@ -271,11 +269,6 @@ void VS_CC VSPlaceboShaderCreate(const VSMap *in, VSMap *out, void *userData, VS
     ShaderData *data;
     int err;
     enum pl_log_level log_level;
-
-    if (pthread_mutex_init(&d.lock, NULL) != 0) {
-        vsapi->setError(out, "placebo.Shader: mutex init failed\n");
-        return;
-    }
 
     log_level = vsapi->propGetInt(in, "log_level", 0, &err);
     if (err)

--- a/src/shader.c
+++ b/src/shader.c
@@ -224,11 +224,13 @@ static const VSFrameRef *VS_CC VSPlaceboShaderGetFrame(int n, int activationReas
         void *packed_dst = malloc(d->width * d->height * 2 * 3);
 
         pthread_mutex_lock(&d->lock);
+        pthread_mutex_lock(&vspl_vulkan_mutex);
 
         if (vspl_shader_reconfig(d->vf, planes, vsapi, d)) {
             vspl_shader_filter(d->vf, packed_dst, planes, d, n, vsapi);
         }
 
+        pthread_mutex_unlock(&vspl_vulkan_mutex);
         pthread_mutex_unlock(&d->lock);
 
         struct p2p_buffer_param pack_params = {

--- a/src/shader.c
+++ b/src/shader.c
@@ -436,5 +436,5 @@ void VS_CC VSPlaceboShaderCreate(const VSMap *in, VSMap *out, void *userData, VS
     data = malloc(sizeof(d));
     *data = d;
 
-    vsapi->createFilter(in, out, "Shader", VSPlaceboShaderInit, VSPlaceboShaderGetFrame, VSPlaceboShaderFree, fmParallel, 0, data, core);
+    vsapi->createFilter(in, out, "Shader", VSPlaceboShaderInit, VSPlaceboShaderGetFrame, VSPlaceboShaderFree, fmSerial, 0, data, core);
 }

--- a/src/tonemap.c
+++ b/src/tonemap.c
@@ -36,8 +36,6 @@ typedef struct {
     struct pl_color_space *src_pl_csp;
     struct pl_color_space *dst_pl_csp;
 
-    pthread_mutex_t lock;
-
     float original_src_max;
     float original_src_min;
     
@@ -483,7 +481,6 @@ static void VS_CC VSPlaceboTMFree(void *instanceData, VSCore *core, const VSAPI 
     free((void *) tm_data->renderParams->color_map_params);
     free(tm_data->renderParams);
 
-    pthread_mutex_destroy(&tm_data->lock);
     free(tm_data);
 }
 
@@ -492,12 +489,6 @@ void VS_CC VSPlaceboTMCreate(const VSMap *in, VSMap *out, void *userData, VSCore
     TMData *tm_data;
     int err;
     enum pl_log_level log_level;
-
-    if (pthread_mutex_init(&d.lock, NULL) != 0)
-    {
-        vsapi->setError(out, "placebo.Tonemap: mutex init failed\n");
-        return;
-    }
 
     log_level = vsapi->propGetInt(in, "log_level", 0, &err);
     if (err)

--- a/src/tonemap.c
+++ b/src/tonemap.c
@@ -439,9 +439,11 @@ static const VSFrameRef *VS_CC VSPlaceboTMGetFrame(int n, int activationReason, 
         void *packed_dst = malloc(w * h * 2 * 3);
         pthread_mutex_lock(&tm_data->lock); // libplacebo isn’t thread-safe
 
+        pthread_mutex_lock(&vspl_vulkan_mutex);
         if (vspl_tonemap_reconfig(tm_data->vf, planes, vsapi)) {
             vspl_tonemap_filter(tm_data, packed_dst, planes, vsapi, src_repr, dst_repr);
         }
+        pthread_mutex_unlock(&vspl_vulkan_mutex);
 
         pthread_mutex_unlock(&tm_data->lock);
 

--- a/src/tonemap.c
+++ b/src/tonemap.c
@@ -670,5 +670,5 @@ void VS_CC VSPlaceboTMCreate(const VSMap *in, VSMap *out, void *userData, VSCore
     tm_data = malloc(sizeof(d));
     *tm_data = d;
 
-    vsapi->createFilter(in, out, "Tonemap", VSPlaceboTMInit, VSPlaceboTMGetFrame, VSPlaceboTMFree, fmParallel, 0, tm_data, core);
+    vsapi->createFilter(in, out, "Tonemap", VSPlaceboTMInit, VSPlaceboTMGetFrame, VSPlaceboTMFree, fmSerial, 0, tm_data, core);
 }

--- a/src/tonemap.c
+++ b/src/tonemap.c
@@ -437,15 +437,12 @@ static const VSFrameRef *VS_CC VSPlaceboTMGetFrame(int n, int activationReason, 
         }
 
         void *packed_dst = malloc(w * h * 2 * 3);
-        pthread_mutex_lock(&tm_data->lock); // libplacebo isn’t thread-safe
 
         pthread_mutex_lock(&vspl_vulkan_mutex);
         if (vspl_tonemap_reconfig(tm_data->vf, planes, vsapi)) {
             vspl_tonemap_filter(tm_data, packed_dst, planes, vsapi, src_repr, dst_repr);
         }
         pthread_mutex_unlock(&vspl_vulkan_mutex);
-
-        pthread_mutex_unlock(&tm_data->lock);
 
         struct p2p_buffer_param pack_params = {
             .width = w,

--- a/src/vs-placebo.c
+++ b/src/vs-placebo.c
@@ -10,6 +10,8 @@
 #include "resample.h"
 #include "shader.h"
 
+pthread_mutex_t vspl_vulkan_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 void *VSPlaceboInit(enum pl_log_level log_level) {
     struct priv *p = calloc(1, sizeof(struct priv));
     if (!p)

--- a/src/vs-placebo.h
+++ b/src/vs-placebo.h
@@ -1,12 +1,15 @@
 #ifndef VS_PLACEBO_LIBRARY_H
 #define VS_PLACEBO_LIBRARY_H
 
+#include <pthread.h>
 #include <libplacebo/dispatch.h>
 #include <libplacebo/shaders/sampling.h>
 #include <libplacebo/utils/upload.h>
 #include <libplacebo/vulkan.h>
 
 #include "config_vsplacebo.h"
+
+extern pthread_mutex_t vspl_vulkan_mutex;
 
 struct format {
     int num_comps;


### PR DESCRIPTION
**The Bug:**
When using multiple instances of `vs-placebo` filters (e.g., two `Deband` nodes) in parallel—such as feeding them into a `MaskedMerge`—the plugin frequently triggers a hard crash with an Access Violation (`0xc0000005`). 

This reliably happens in complex VapourSynth scripts where parallel threads request frames from different `vs-placebo` instances simultaneously, especially when reading from the same source frame memory.

*Minimal Reproducer:*
```python
# This script crashes the VapourSynth process without this PR

import vapoursynth as vs
from vapoursynth import core

src16 = core.std.BlankClip(width=1920, height=1080, format=vs.YUV420P16, length=5000)
shuffled = core.std.ShufflePlanes([src16, src16], [0, 1, 2], vs.YUV)
dbed1 = core.placebo.Deband(shuffled, radius=16, threshold=2.5)
dbed2 = core.placebo.Deband(shuffled, radius=12, threshold=1.0)

# MaskedMerge forces VS to evaluate dbed1 and dbed2 concurrently
res = core.std.MaskedMerge(dbed1, dbed2, core.std.ShufflePlanes(src16, 0, vs.GRAY))

res.set_output()
```

Using this script for processing will exit midway and leave an error on eventvwr:

<img width="1373" height="821" alt="Event log" src="https://github.com/user-attachments/assets/38bc3d17-9ee0-4f39-b51c-e9a10573cc69" />

**The Cause:**
Currently, `vs-placebo` creates an independent Vulkan context (`pl_vulkan_create`) for *every single filter instance*. When VapourSynth evaluates multiple instances in parallel threads, these independent Vulkan contexts concurrently hammer the GPU driver. 
More importantly, when they attempt to map, upload, and dispatch from the exact same CPU memory addresses (the shared `VSFrame` from previous nodes) simultaneously, the underlying Vulkan queues and driver state machine collide, causing a fatal segfault.

**Fix:**
Switched Registration to fmSerial: Changed the VapourSynth filter registration mode from fmParallel to fmSerial. Initially in our debugging process, we applied this change to prevent VapourSynth from evaluating the same filter instance concurrently. This successfully mitigated some early instabilities, but complex multi-instance scripts still crashed, leading to the second step.
Global Vulkan Mutex: Introduced vspl_vulkan_mutex in vs-placebo.c to handle multi-instance collisions.
Monolithic GPU Block: Wrapped the entire GPU interaction lifecycle (the upload_plane loop -> do_image -> download_planes) inside this global lock within the get_frame function.

**Why wrap the entire block?**
Attempting to lock only the `upload` and `download` separately still caused crashes. The Vulkan submission from `upload` to `download` must be treated as an uninterrupted, atomic state machine. By globally locking this specific GPU block, Vulkan Context A completely finishes its work before Vulkan Context B can touch the driver/memory. 

**Why keep fmSerial?**
Even though we added a global lock and there is an existing instance lock (dbd_data->lock), keeping fmSerial is crucial for two reasons:

Scheduler Efficiency: Since the actual GPU submission is now serialized globally, processing the same filter instance in parallel (fmParallel) provides zero performance benefit. It only causes VapourSynth worker threads to pile up and sleep waiting for the instance/global locks. fmSerial tells the VS scheduler the truth, allowing it to allocate those worker threads to other non-blocking tasks (like CPU decoding or other filters).

*Performance Note:* CPU preparations (like VapourSynth frame fetching) remain fully multi-threaded. The lock only throttles the extremely fast GPU command submissions, completely eliminating the crashes with no noticeable impact on overall FPS.
